### PR TITLE
FIX: Google link to lint rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var getFileLink = function(_path, line, column) {
 
 var getKeyLink = function(key) {
   var noLinkRules = parseBoolEnvVar('EFF_NO_LINK_RULES');
-  var url = key.indexOf('/') > -1 ? 'https://google.com/#q=' : 'http://eslint.org/docs/rules/';
+  var url = key.indexOf('/') > -1 ? 'https://google.com/search?q=' : 'http://eslint.org/docs/rules/';
   return (!noLinkRules) ? chalk.underline(subtleLog(url + chalk.white(encodeURIComponent(key)))) : chalk.white(key);
 };
 


### PR DESCRIPTION
Ported from old repository:  royriojas/eslint-friendly-formatter#46