### PR TITLE
FIX: codeFrame => codeFrameColumns

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ module.exports = function(results) {
           };
           const codeFrameOptions = tryParseJSONObject(getEnvVar("EFF_CODE_FRAME_OPTIONS")) || { highlightCode: true };
 
-          return showSource ? codeFrame(
+          return showSource ? codeFrameColumns(
               message.fileSource,
               location,
               codeFrameOptions


### PR DESCRIPTION
Fixes error introduced in #10. Not sure how I managed that back then 🤨

@royriojas Would it be possible to also publish a new version on NPM? (and perhaps update the repository URL so NPM doesn't point to the old "eslint-friendly-formatter" repository)